### PR TITLE
Changed event fields for consistency between lhd and nwplus

### DIFF
--- a/components/Events.vue
+++ b/components/Events.vue
@@ -26,10 +26,10 @@
             {{ item.date }}
           </p>
           <p class="blurb">
-            {{ item.blurb }}
+            {{ item.blurb || item.text }}
           </p>
-          <Button disabled title="Sign up" url="#" class="buttonLabel" />
-          <Button disabled title="Event page" url="#" class="buttonLabel" />
+          <Button disabled title="Sign up" :url="item.signupLink || '#'" class="buttonLabel" />
+          <Button disabled title="Event page" :url="item.eventLink || '#'" class="buttonLabel" />
         </div>
       </div>
     </div>

--- a/components/Events.vue
+++ b/components/Events.vue
@@ -28,8 +28,8 @@
           <p class="blurb">
             {{ item.blurb || item.text }}
           </p>
-          <Button disabled title="Sign up" :url="item.signupLink || '#'" class="buttonLabel" />
-          <Button disabled title="Event page" :url="item.eventLink || '#'" class="buttonLabel" />
+          <Button :disabled="item.signupEnabled ? false : true" title="Sign up" :url="item.signupLink || '#'" class="buttonLabel" />
+          <Button :disabled="item.signupEnabled ? false : true" title="Event page" :url="item.eventLink || '#'" class="buttonLabel" />
         </div>
       </div>
     </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,7 +7,7 @@
         <Bulletin />
         <WhyJoin id="about" />
         <Events id="events" :items="events" />
-        <FAQ v-if="FAQFlag" id="faq" :items="FAQs" />
+        <FAQ v-if="faqFlag" id="faq" :items="FAQs" />
         <Outro id="contact" :text="outro" />
         <Sponza id="sponza" />
       </div>
@@ -65,7 +65,6 @@ export default {
       intro: data.IntroText,
       introSub: data.IntroSubtext,
       FAQs: FaqQuestions,
-      FAQFlag: data.flags.faq,
       ...data.featureFlags
     }
   }


### PR DESCRIPTION
The fields in firebase are inconsistent between lhd and nwplus. Namely, the text is "text" in nwplus and "blurb" in lhd. These fields should be consistent so that they can be edited with the cms. We should also add "eventLink" and "signupLink" fields