### PR TITLE
Remove snowflakes when client prefers reduced motion

### DIFF
--- a/components/Intro.vue
+++ b/components/Intro.vue
@@ -139,4 +139,10 @@ export default {
 .snow {
   height: 20% !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .snow {
+    display: none;
+  }
+}
 </style>


### PR DESCRIPTION
This PR aims to improve the accessibility of the LHD site by removing the falling snowflake animation when a client prefers an interface with reduced motion. 

## :construction_worker: Changes

Using the [`prefers-reduced-motion` Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion), we simply `display:none` the snowflake canvas. 

## :flashlight: Testing Instructions (Mac)
1. Visit the site and note the animation 
2. Go into System Preferences -> Accessibility -> select Reduce Motion
3. Return to the site and note the animation no longer exists

![reduce-motion-lhd](https://user-images.githubusercontent.com/1896810/72936111-72f08c80-3d1b-11ea-8a60-8b336de2b801.gif)

