### PR TITLE
update email

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -49,7 +49,7 @@
 
         <p class="links">
           <a
-            href="mailto:hello@nwplus.io"
+            href="mailto:info@nwplus.io"
           >Email Us</a>
           <a
             href="#"

--- a/components/Outro.vue
+++ b/components/Outro.vue
@@ -3,8 +3,8 @@
     <p>
       nwPlus is always looking for new ventures, opportunities, and connections. If you are interested in working with us, joining us or speaking at one of our events, feel free to reach out to us at
       <a
-        href="mailto:hello@nwplus.io"
-      >hello@nwplus.io</a>.
+        href="mailto:info@nwplus.io"
+      >info@nwplus.io</a>.
     </p>
   </div>
 </template>


### PR DESCRIPTION
👷 Changes
A brief summary of what changes were introduced.

Changed default "reach us" email of nwplus
💭 Notes
Any additional things to take into consideration.
It wouldn't hurt anyone to change this. At worst if they finally figure out how to get access to hello@nwplus.io then info@nwplus.io can just forward email to that account

🔦 Testing Instructions
Explain how to test your changes, if applicable.
Just click on the link and check out the text.